### PR TITLE
Add KDL syntax highlighting

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,7 @@ const {
   MessageChannel,
 } = require("worker_threads");
 
+// See https://giuseppegurgone.com/synchronizing-async-functions/
 function wait_highlight(...args) {
   const worker = new Worker("./highlight_worker.js");
   const signal = new Int32Array(new SharedArrayBuffer(4));

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,7 +12,7 @@ function wait_highlight(...args) {
   try {
     const subChannel = new MessageChannel();
     worker.postMessage({ signal, port: subChannel.port1, args }, [
-        subChannel.port1
+      subChannel.port1,
     ]);
     Atomics.wait(signal, 0, 0);
     return receiveMessageOnPort(subChannel.port2).message.result;

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,28 @@
+const {
+  Worker,
+  receiveMessageOnPort,
+  MessageChannel,
+} = require("worker_threads");
+
+function wait_highlight(...args) {
+  const worker = new Worker("./highlight_worker.js");
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  signal[0] = 0;
+  try {
+    const subChannel = new MessageChannel();
+    worker.postMessage({ signal, port: subChannel.port1, args }, [
+        subChannel.port1
+    ]);
+    Atomics.wait(signal, 0, 0);
+    return receiveMessageOnPort(subChannel.port2).message.result;
+  } finally {
+    worker.unref();
+  }
+}
+
 module.exports = (eleventyConfig) => {
   eleventyConfig.addPassthroughCopy("src/CNAME");
+  eleventyConfig.addMarkdownHighlighter(wait_highlight);
 
   return {
     dir: {

--- a/highlight_worker.js
+++ b/highlight_worker.js
@@ -3,19 +3,17 @@ const shiki = require("shiki");
 const path = require("path");
 
 async function shiki_highlight(code, lang) {
-  const highlighter = await 
-  shiki
-    .getHighlighter({
-      theme: 'nord',
-      langs: [
-        {
-          id: "kdl",
-          scopeName: "source.kdl",
-          path: path.join(process.cwd(), "kdl.tmLanguage.json")
-        }
-      ]
-    })
-    return highlighter.codeToHtml(code, lang)
+  const highlighter = await shiki.getHighlighter({
+    theme: "nord",
+    langs: [
+      {
+        id: "kdl",
+        scopeName: "source.kdl",
+        path: path.join(process.cwd(), "kdl.tmLanguage.json"),
+      },
+    ],
+  });
+  return highlighter.codeToHtml(code, lang);
 }
 
 parentPort.addListener("message", async ({ signal, port, args }) => {
@@ -25,7 +23,7 @@ parentPort.addListener("message", async ({ signal, port, args }) => {
   // Post the result to the main thread before unlocking "signal"
   port.postMessage({ result });
   port.close();
-  
+
   // Change the value of signal[0] to 1
   Atomics.store(signal, 0, 1);
   // This will unlock the main thread when we notify it

--- a/highlight_worker.js
+++ b/highlight_worker.js
@@ -1,0 +1,33 @@
+const { parentPort } = require("worker_threads");
+const shiki = require("shiki");
+const path = require("path");
+
+async function shiki_highlight(code, lang) {
+  const highlighter = await 
+  shiki
+    .getHighlighter({
+      theme: 'nord',
+      langs: [
+        {
+          id: "kdl",
+          scopeName: "source.kdl",
+          path: path.join(process.cwd(), "kdl.tmLanguage.json")
+        }
+      ]
+    })
+    return highlighter.codeToHtml(code, lang)
+}
+
+parentPort.addListener("message", async ({ signal, port, args }) => {
+  // This is the async function that we want to run "synchronously"
+  const result = await shiki_highlight(...args);
+
+  // Post the result to the main thread before unlocking "signal"
+  port.postMessage({ result });
+  port.close();
+  
+  // Change the value of signal[0] to 1
+  Atomics.store(signal, 0, 1);
+  // This will unlock the main thread when we notify it
+  Atomics.notify(signal, 0);
+});

--- a/kdl.tmLanguage.json
+++ b/kdl.tmLanguage.json
@@ -1,45 +1,45 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"comment":"Some of these patterns are taken straight from rust-analyzer: https://github.com/rust-lang/vscode-rust/blob/master/rust-analyzer/editors/code/rust.tmGrammar.json. Some was also taken from https://github.com/arm32x/vscode-sdlang/blob/master/syntaxes/sdlang.tmLanguage.json",
-	"name": "KDL",
-	"patterns": [
-		{
-			"include": "#null"
-		},
-		{
-			"include": "#boolean"
-		},
-		{
-			"include": "#float_fraction"
-		},
-		{
-			"include": "#float_exp"
-		},
-		{
-			"include": "#decimal"
-		},
-		{
-			"include": "#hexadecimal"
-		},
-		{
-			"include": "#octal"
-		},
-		{
-			"include": "#binary"
-		},
-		{
-			"include": "#raw-strings"
-		},
-		{
-			"include": "#strings"
-		},
-		{
-			"include": "#block_comment"
-		},
-		{
-			"include": "#block_doc_comment"
-		},
-		{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "comment": "Some of these patterns are taken straight from rust-analyzer: https://github.com/rust-lang/vscode-rust/blob/master/rust-analyzer/editors/code/rust.tmGrammar.json. Some was also taken from https://github.com/arm32x/vscode-sdlang/blob/master/syntaxes/sdlang.tmLanguage.json",
+  "name": "KDL",
+  "patterns": [
+    {
+      "include": "#null"
+    },
+    {
+      "include": "#boolean"
+    },
+    {
+      "include": "#float_fraction"
+    },
+    {
+      "include": "#float_exp"
+    },
+    {
+      "include": "#decimal"
+    },
+    {
+      "include": "#hexadecimal"
+    },
+    {
+      "include": "#octal"
+    },
+    {
+      "include": "#binary"
+    },
+    {
+      "include": "#raw-strings"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#block_comment"
+    },
+    {
+      "include": "#block_doc_comment"
+    },
+    {
       "include": "#slashdash_block_comment"
     },
     {
@@ -48,119 +48,119 @@
     {
       "include": "#slashdash_node_comment"
     },
-		{
-			"include": "#line_comment"
-		},
-		{
-			"include": "#attribute"
-		},
-		{
-			"include": "#node_name"
-		}
-	],
-	"repository": {
-		"float_fraction": {
-			"comment": "Floating point literal (fraction)",
-			"name": "constant.numeric.float.rust",
-			"match": "\\b([0-9\\-\\+]|\\-|\\+)[0-9_]*\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?\\b"
-		},
-		"float_exp": {
-			"comment": "Floating point literal (exponent)",
-			"name": "constant.numeric.float.rust",
-			"match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?[eE][+-]?[0-9_]+\\b"
-		},
-		"decimal": {
-			"comment": "Integer literal (decimal)",
-			"name": "constant.numeric.integer.decimal.rust",
-			"match": "\\b[0-9\\-\\+][0-9_]*\\b"
-		},
-		"hexadecimal": {
-			"comment": "Integer literal (hexadecimal)",
-			"name": "constant.numeric.integer.hexadecimal.rust",
-			"match": "\\b0x[a-fA-F0-9_]+\\b"
-		},
-		"octal": {
-			"comment": "Integer literal (octal)",
-			"name": "constant.numeric.integer.octal.rust",
-			"match": "\\b0o[0-7_]+\\b"
-		},
-		"binary": {
-			"comment": "Integer literal (binary)",
-			"name": "constant.numeric.integer.binary.rust",
-			"match": "\\b0b[01_]+\\b"
-		},
-		"node_name": {
-			"name": "entity.name.tag",
-			"match": "(?![\\\\{\\}<>;\\[\\]\\=,])[\\w\\-_~!@#\\$%^&*+|/.\\(\\)]+"
-		},
-		"attribute": {
-			"name": "entity.other.attribute-name.kdl",
-			"match": "(?![\\\\{\\}<>;\\[\\]\\=,])[\\w\\-_~!@#\\$%^&*+|/.]+(=)",
-			"captures": {
-				"1": {
-					"name": "punctuation.separator.key-value.kdl"
-				}
-			}
-		},
-		"null": {
-			"name": "constant.language.null.kdl",
-			"match": "\\bnull\\b"
-		},
-		"boolean": {
-			"name": "constant.language.boolean.kdl",
-			"match": "\\b(true|false)\\b"
-		},
-		"strings": {
-			"name": "string.quoted.double.kdl",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.kdl",
-					"match": "\\\\(:?[nrtbf\\\\\"]|u\\{[a-fA-F0-9]{1,6}\\})"
-				}
-			]
-		},
-		"raw-strings": {
-			"name": "string.quoted.double.raw.kdl",
-			"begin": "b?r(#*)\"",
-			"end": "\"\\1"
-		},
-		"block_doc_comment": {
-			"comment": "Block documentation comment",
-			"name": "comment.block.documentation.kdl",
-			"begin": "/\\*[\\*!](?![\\*/])",
-			"end": "\\*/",
-			"patterns": [
-				{
-					"include": "#block_doc_comment"
-				},
-				{
-					"include": "#block_comment"
-				}
-			]
-		},
-		"block_comment": {
-			"comment": "Block comment",
-			"name": "comment.block.kdl",
-			"begin": "/\\*",
-			"end": "\\*/",
-			"patterns": [
-				{
-					"include": "#block_doc_comment"
-				},
-				{
-					"include": "#block_comment"
-				}
-			]
-		},
-		"line_comment": {
-			"comment": "Single-line comment",
-			"name": "comment.line.double-slash.rust",
-			"begin": "//",
-			"end": "$"
-		},
-		"slashdash_comment": {
+    {
+      "include": "#line_comment"
+    },
+    {
+      "include": "#attribute"
+    },
+    {
+      "include": "#node_name"
+    }
+  ],
+  "repository": {
+    "float_fraction": {
+      "comment": "Floating point literal (fraction)",
+      "name": "constant.numeric.float.rust",
+      "match": "\\b([0-9\\-\\+]|\\-|\\+)[0-9_]*\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?\\b"
+    },
+    "float_exp": {
+      "comment": "Floating point literal (exponent)",
+      "name": "constant.numeric.float.rust",
+      "match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?[eE][+-]?[0-9_]+\\b"
+    },
+    "decimal": {
+      "comment": "Integer literal (decimal)",
+      "name": "constant.numeric.integer.decimal.rust",
+      "match": "\\b[0-9\\-\\+][0-9_]*\\b"
+    },
+    "hexadecimal": {
+      "comment": "Integer literal (hexadecimal)",
+      "name": "constant.numeric.integer.hexadecimal.rust",
+      "match": "\\b0x[a-fA-F0-9_]+\\b"
+    },
+    "octal": {
+      "comment": "Integer literal (octal)",
+      "name": "constant.numeric.integer.octal.rust",
+      "match": "\\b0o[0-7_]+\\b"
+    },
+    "binary": {
+      "comment": "Integer literal (binary)",
+      "name": "constant.numeric.integer.binary.rust",
+      "match": "\\b0b[01_]+\\b"
+    },
+    "node_name": {
+      "name": "entity.name.tag",
+      "match": "(?![\\\\{\\}<>;\\[\\]\\=,])[\\w\\-_~!@#\\$%^&*+|/.\\(\\)]+"
+    },
+    "attribute": {
+      "name": "entity.other.attribute-name.kdl",
+      "match": "(?![\\\\{\\}<>;\\[\\]\\=,])[\\w\\-_~!@#\\$%^&*+|/.]+(=)",
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.key-value.kdl"
+        }
+      }
+    },
+    "null": {
+      "name": "constant.language.null.kdl",
+      "match": "\\bnull\\b"
+    },
+    "boolean": {
+      "name": "constant.language.boolean.kdl",
+      "match": "\\b(true|false)\\b"
+    },
+    "strings": {
+      "name": "string.quoted.double.kdl",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.kdl",
+          "match": "\\\\(:?[nrtbf\\\\\"]|u\\{[a-fA-F0-9]{1,6}\\})"
+        }
+      ]
+    },
+    "raw-strings": {
+      "name": "string.quoted.double.raw.kdl",
+      "begin": "b?r(#*)\"",
+      "end": "\"\\1"
+    },
+    "block_doc_comment": {
+      "comment": "Block documentation comment",
+      "name": "comment.block.documentation.kdl",
+      "begin": "/\\*[\\*!](?![\\*/])",
+      "end": "\\*/",
+      "patterns": [
+        {
+          "include": "#block_doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "block_comment": {
+      "comment": "Block comment",
+      "name": "comment.block.kdl",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "patterns": [
+        {
+          "include": "#block_doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "line_comment": {
+      "comment": "Single-line comment",
+      "name": "comment.line.double-slash.rust",
+      "begin": "//",
+      "end": "$"
+    },
+    "slashdash_comment": {
       "name": "comment.line.double-slash",
       "comment": "Slashdash inline comment",
       "begin": "(?<!^)/-",
@@ -178,6 +178,6 @@
       "begin": "/-{",
       "end": "}"
     }
-	},
-	"scopeName": "source.kdl"
+  },
+  "scopeName": "source.kdl"
 }

--- a/kdl.tmLanguage.json
+++ b/kdl.tmLanguage.json
@@ -1,0 +1,183 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"comment":"Some of these patterns are taken straight from rust-analyzer: https://github.com/rust-lang/vscode-rust/blob/master/rust-analyzer/editors/code/rust.tmGrammar.json. Some was also taken from https://github.com/arm32x/vscode-sdlang/blob/master/syntaxes/sdlang.tmLanguage.json",
+	"name": "KDL",
+	"patterns": [
+		{
+			"include": "#null"
+		},
+		{
+			"include": "#boolean"
+		},
+		{
+			"include": "#float_fraction"
+		},
+		{
+			"include": "#float_exp"
+		},
+		{
+			"include": "#decimal"
+		},
+		{
+			"include": "#hexadecimal"
+		},
+		{
+			"include": "#octal"
+		},
+		{
+			"include": "#binary"
+		},
+		{
+			"include": "#raw-strings"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#block_comment"
+		},
+		{
+			"include": "#block_doc_comment"
+		},
+		{
+      "include": "#slashdash_block_comment"
+    },
+    {
+      "include": "#slashdash_comment"
+    },
+    {
+      "include": "#slashdash_node_comment"
+    },
+		{
+			"include": "#line_comment"
+		},
+		{
+			"include": "#attribute"
+		},
+		{
+			"include": "#node_name"
+		}
+	],
+	"repository": {
+		"float_fraction": {
+			"comment": "Floating point literal (fraction)",
+			"name": "constant.numeric.float.rust",
+			"match": "\\b([0-9\\-\\+]|\\-|\\+)[0-9_]*\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?\\b"
+		},
+		"float_exp": {
+			"comment": "Floating point literal (exponent)",
+			"name": "constant.numeric.float.rust",
+			"match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?[eE][+-]?[0-9_]+\\b"
+		},
+		"decimal": {
+			"comment": "Integer literal (decimal)",
+			"name": "constant.numeric.integer.decimal.rust",
+			"match": "\\b[0-9\\-\\+][0-9_]*\\b"
+		},
+		"hexadecimal": {
+			"comment": "Integer literal (hexadecimal)",
+			"name": "constant.numeric.integer.hexadecimal.rust",
+			"match": "\\b0x[a-fA-F0-9_]+\\b"
+		},
+		"octal": {
+			"comment": "Integer literal (octal)",
+			"name": "constant.numeric.integer.octal.rust",
+			"match": "\\b0o[0-7_]+\\b"
+		},
+		"binary": {
+			"comment": "Integer literal (binary)",
+			"name": "constant.numeric.integer.binary.rust",
+			"match": "\\b0b[01_]+\\b"
+		},
+		"node_name": {
+			"name": "entity.name.tag",
+			"match": "(?![\\\\{\\}<>;\\[\\]\\=,])[\\w\\-_~!@#\\$%^&*+|/.\\(\\)]+"
+		},
+		"attribute": {
+			"name": "entity.other.attribute-name.kdl",
+			"match": "(?![\\\\{\\}<>;\\[\\]\\=,])[\\w\\-_~!@#\\$%^&*+|/.]+(=)",
+			"captures": {
+				"1": {
+					"name": "punctuation.separator.key-value.kdl"
+				}
+			}
+		},
+		"null": {
+			"name": "constant.language.null.kdl",
+			"match": "\\bnull\\b"
+		},
+		"boolean": {
+			"name": "constant.language.boolean.kdl",
+			"match": "\\b(true|false)\\b"
+		},
+		"strings": {
+			"name": "string.quoted.double.kdl",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.kdl",
+					"match": "\\\\(:?[nrtbf\\\\\"]|u\\{[a-fA-F0-9]{1,6}\\})"
+				}
+			]
+		},
+		"raw-strings": {
+			"name": "string.quoted.double.raw.kdl",
+			"begin": "b?r(#*)\"",
+			"end": "\"\\1"
+		},
+		"block_doc_comment": {
+			"comment": "Block documentation comment",
+			"name": "comment.block.documentation.kdl",
+			"begin": "/\\*[\\*!](?![\\*/])",
+			"end": "\\*/",
+			"patterns": [
+				{
+					"include": "#block_doc_comment"
+				},
+				{
+					"include": "#block_comment"
+				}
+			]
+		},
+		"block_comment": {
+			"comment": "Block comment",
+			"name": "comment.block.kdl",
+			"begin": "/\\*",
+			"end": "\\*/",
+			"patterns": [
+				{
+					"include": "#block_doc_comment"
+				},
+				{
+					"include": "#block_comment"
+				}
+			]
+		},
+		"line_comment": {
+			"comment": "Single-line comment",
+			"name": "comment.line.double-slash.rust",
+			"begin": "//",
+			"end": "$"
+		},
+		"slashdash_comment": {
+      "name": "comment.line.double-slash",
+      "comment": "Slashdash inline comment",
+      "begin": "(?<!^)/-",
+      "end": "\\s"
+    },
+    "slashdash_node_comment": {
+      "name": "comment.block",
+      "comment": "Slashdash node comment",
+      "begin": "(?<=^)/-",
+      "end": "}"
+    },
+    "slashdash_block_comment": {
+      "name": "comment.block",
+      "comment": "Slashdash block comment",
+      "begin": "/-{",
+      "end": "}"
+    }
+	},
+	"scopeName": "source.kdl"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1964,6 +1964,15 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "jsonfile": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
@@ -2424,6 +2433,32 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "openurl": {
@@ -3620,6 +3655,37 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.7.tgz",
+      "integrity": "sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "shiki-languages": "^0.2.7",
+        "shiki-themes": "^0.2.7",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
+    "shiki-languages": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.7.tgz",
+      "integrity": "sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==",
+      "dev": true,
+      "requires": {
+        "vscode-textmate": "^5.2.0"
+      }
+    },
+    "shiki-themes": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
+      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.1.0",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -4207,6 +4273,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "which-module": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postcss": "^8.2.1",
     "postcss-cli": "^8.3.1",
     "prettier": "^2.2.1",
-    "tailwindcss": "^2.0.2"
-  },
-  "dependencies": {}
+    "tailwindcss": "^2.0.2",
+    "shiki": "^0.2.7"
+  }
 }


### PR DESCRIPTION
* Use [`shiki`](https://github.com/shikijs/shiki) to do highlighting by using KDL textmate grammar
* Do a little trick to allow `shiki`'s async highlighting to happen synchronously as `eleventy` wants
* All colors are inlined, so no CSS is output

Result:

![image](https://user-images.githubusercontent.com/38713361/103171081-9c4f5c00-488c-11eb-8d66-40cb6a8ae30e.png)
