### PR TITLE
add link to ruby implementation

### DIFF
--- a/src/_includes/partials/implementations.md
+++ b/src/_includes/partials/implementations.md
@@ -4,6 +4,7 @@
 
 * Rust: [kdl-rs](https://github.com/kdl-org/kdl-rs)
 * JavaScript: [kdljs](https://github.com/kdl-org/kdljs)
+* Ruby: [kdl-rb](https://github.com/jellymann/kdl-rb)
 
 ## Editor Support
 


### PR DESCRIPTION
Add a link to the Ruby implementation under the implementations section.

See also:
https://github.com/kdl-org/kdl/issues/53
https://github.com/kdl-org/kdl/pull/58