### PR TITLE
Override the tailwind typography inline code styles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,3 +5,9 @@
 .kdl-section {
   @apply py-10 px-4 prose prose-xl mx-auto;
 }
+
+code {
+  background-color: #efefef;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,12 @@ module.exports = {
       typography: {
         DEFAULT: {
           css: {
+            "code::before": {
+              content: "none",
+            },
+            "code::after": {
+              content: "none",
+            },
             "pre code::after": {
               content: "none",
             },


### PR DESCRIPTION
<img width="356" alt="image" src="https://user-images.githubusercontent.com/1682194/104131831-0ebd4300-5347-11eb-91da-0911a5055723.png">

Definitely open to tweaking the replacement styles some, just thought this would be a good start here.

For comparison, this is the GitHub styling:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/1682194/104131868-5348de80-5347-11eb-98c1-3984250e9514.png">

Closes #9 