### PR TITLE
Add Java implementation to list

### DIFF
--- a/src/_includes/partials/implementations.md
+++ b/src/_includes/partials/implementations.md
@@ -6,6 +6,7 @@
 * JavaScript: [kdljs](https://github.com/kdl-org/kdljs)
 * Ruby: [kdl-rb](https://github.com/jellymann/kdl-rb)
 * Dart: [kdl-dart](https://github.com/jellymann/kdl-dart)
+* Java: [kdl4j](https://github.com/hkolbeck/kdl4j)
 
 ## Editor Support
 


### PR DESCRIPTION
Adds a link to my Java implementation to the list of implementations, per https://github.com/kdl-org/kdl/issues/56#issuecomment-758341642