### PR TITLE
kdl-nim implementation

### DIFF
--- a/src/_includes/partials/implementations.md
+++ b/src/_includes/partials/implementations.md
@@ -16,7 +16,8 @@
 * C: [ckdl](https://github.com/tjol/ckdl)
 * C++: [kdlpp](https://github.com/tjol/ckdl) (part of ckdl, requires C++20)
 * OCaml: [ocaml-kdl](https://github.com/Bannerets/ocaml-kdl)
-
+* Nim: [kdl-nim](https://github.com/Patitotective/kdl-nim)
+  
 ## Editor Support
 
 * [VS Code](https://marketplace.visualstudio.com/items?itemName=kdl-org.kdl&ssr=false#review-details)


### PR DESCRIPTION
Added [kdl-nim](https://github.com/Patitotective/kdl-nim) to `implementations.md`.
:heart: 