### PR TITLE
bump KDL parser to improve errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
         "@11ty/eleventy-plugin-vite": "^6.0.0-alpha.3",
-        "@bgotink/kdl": "^0.2.1",
+        "@bgotink/kdl": "^0.3.1",
         "@parcel/packager-raw-url": "^2.13.3",
         "@parcel/transformer-webmanifest": "^2.13.3",
         "@tailwindcss/typography": "^0.3.1",
@@ -339,10 +339,11 @@
       }
     },
     "node_modules/@bgotink/kdl": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bgotink/kdl/-/kdl-0.2.1.tgz",
-      "integrity": "sha512-0VeRezpHzoyZ15iEdnmsAsQYLywl6icLUzzf8kCIwsHEL5oYXFBOylnuVGv9nvSX//Q+XECaLTi8B9vGD1RG/Q==",
-      "dev": true
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@bgotink/kdl/-/kdl-0.3.1.tgz",
+      "integrity": "sha512-EQQpjS3RiYNlUymAeO06WUrphzSdmbXzQrJ4s8JAr0Ft5WE67s23i5JaulZ3BO0yHA4tMkUT2cHWEgAq5iJC8Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "shiki": "^1.24.2",
     "svgo": "^3.3.2",
     "tailwindcss": "^2.0.2",
-    "@bgotink/kdl": "^0.2.1",
+    "@bgotink/kdl": "^0.3.1",
     "monaco-editor": "^0.52.0",
     "monaco-themes": "^0.4.4"
   },

--- a/static/play/play.js
+++ b/static/play/play.js
@@ -117,10 +117,10 @@ addEventListener("DOMContentLoaded", (event) => {
         markers.push({
           message: error.message,
           severity: monaco.MarkerSeverity.Error,
-          startLineNumber: error.token?.start.line,
-          startColumn: error.token?.start.column,
-          endLineNumber: error.token?.end.line,
-          endColumn: error.token?.end.column,
+          startLineNumber: error.start?.line,
+          startColumn: error.start?.column,
+          endLineNumber: error.end?.line,
+          endColumn: error.end?.column,
         })
       } else if (typeof AggregateError === 'function' && error instanceof AggregateError) {
         for (const suberror of error.errors) {
@@ -128,10 +128,10 @@ addEventListener("DOMContentLoaded", (event) => {
             markers.push({
               message: suberror.message,
               severity: monaco.MarkerSeverity.Error,
-              startLineNumber: suberror.token?.start.line,
-              startColumn: suberror.token?.start.column,
-              endLineNumber: suberror.token?.end.line,
-              endColumn: suberror.token?.end.column,
+              startLineNumber: suberror.start?.line,
+              startColumn: suberror.start?.column,
+              endLineNumber: suberror.end?.line,
+              endColumn: suberror.end?.column,
             })
           } else {
             console.error(suberror);


### PR DESCRIPTION
The new version of the parser makes more of the parsing errors recoverable, improves the source locations included in the errors to allow targeting individual characters instead of being token based, and finally it also improves on a few error messages.

**Before**

<img width="356" alt="screenshot of the KDL playground showing a document with many mistakes, but only three at the top of the document are highlighted by the editor" src="https://github.com/user-attachments/assets/c734d1b5-be3f-4e74-b10d-c7139b830bbd" />

The error on the `foo` node is actually due to the invalid binary number which is both non-recoverable and lacks the proper location info.
If I remove a few errors from the document, the parser can continue on to discover issues in the strings which are marked completely invalid:

<img width="268" alt="the same screenshot as above but other errors are shown" src="https://github.com/user-attachments/assets/a3f6d089-f5a0-4308-bb53-93577dc652c0" />

**After**

<img width="417" alt="screenshot of the same KDL document as above, but it shows many more errors throughout the entire document, many of which highlight the specific character or characters that causes the error" src="https://github.com/user-attachments/assets/2190de42-4d64-44a1-860e-f574ea57c14d" />
