### PR TITLE
fix /spec-v1 title heading

### DIFF
--- a/src/spec-v1.md
+++ b/src/spec-v1.md
@@ -5,6 +5,7 @@ title: KDL v1 Specification
 
 <!-- TODO: actually make proper sections for this someday? meh, probably pointless. -->
 <section class="kdl-section" id="spec">
+
 # KDL v1 Spec
 
 This is the semi-formal specification for the legacy version of KDL, including


### PR DESCRIPTION
Needs a newline here between the HTML element and the markdown syntax for it to be rendered correctly :)