### PR TITLE
 docs: adds missing Typescript DOM generator

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -110,6 +110,7 @@ of some examples of KDL in the wild (either v1, v2, or both):
 * [mise](https://mise.jdx.dev/) - dev tools, env vars, task runner
 * [Camping](https://github.com/camping/camping) - Ruby web microframework
 * [Iron Vault](https://ironvault.quest) - VTT (Virtual Tabletop) plugin for Obsidian for the Ironsworn family of games
+* [Microsoft TypeScript DOM Generator](https://github.com/microsoft/TypeScript-DOM-lib-generator) - Tool for generating DOM-related TypeScript and JavaScript library files
 * You?
 
 </section>


### PR DESCRIPTION
Typescript DOM generator is currently integrating KDL

Links:
https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/2053
https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/2064
https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/2082
https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/2085