### PR TITLE
Add Nova extension

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -172,6 +172,7 @@ of some examples of KDL in the wild (either v1, v2, or both):
 * [vim](https://github.com/imsnif/kdl.vim)
 * [Kate](https://github.com/larsgw/katepart-kdl)\*
 * [Zed](https://zed.dev/extensions/kdl)
+* [Nova](https://extensions.panic.com/extensions/net.marquiskurt/net.marquiskurt.kdl-lang/)
 
 \* Supports KDL 2.0.0
 


### PR DESCRIPTION
[Nova](https://nova.app) is a code editor created by Panic. In late 2023, I created the Cuddle extension to give me basic syntax highlighting support for KDL documents in my projects. As to why it’s taken me until now to add it to this page is beyond me.

[Extension homepage &rsaquo;](https://extensions.panic.com/extensions/net.marquiskurt/net.marquiskurt.kdl-lang/)  
[Extension source code &rsaquo;](https://gitlab.com/marquiskurt/KDL)  

<img width="3208" height="2072" alt="image" src="https://github.com/user-attachments/assets/cc6b5cbd-bdf1-49da-9724-774e07c7a79e" />
