### PR TITLE
Add kadokit for creating embedded GUIs defined as KDL files

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -113,6 +113,7 @@ of some examples of KDL in the wild (either v1, v2, or both):
 * [Iron Vault](https://ironvault.quest) - VTT (Virtual Tabletop) plugin for Obsidian for the Ironsworn family of games
 * [Microsoft TypeScript DOM Generator](https://github.com/microsoft/TypeScript-DOM-lib-generator) - Tool for generating DOM-related TypeScript and JavaScript library files
 * [Ferron](https://ferron.sh/) - A fast, memory-safe web server written in Rust
+* [kadokit](https://kadokit.com/) - Declarative UI kit for embedded devices that uses KDL documents to define reactive interfaces.
 * You?
 
 </section>


### PR DESCRIPTION
I used KDL as a DSL to declare widgets and attach javascript code to create GUIs intended for embedded devices. This work took me many months to use the KDL the right way for my case. 
I created the website and I'm planning to provide many examples as a github repo.

I'll use this pull request also to ask for feedback on my particular use case.